### PR TITLE
Support PPC64LE and Fix build by MCST lcc compiler on e2k

### DIFF
--- a/neo/CMakeLists.txt
+++ b/neo/CMakeLists.txt
@@ -57,7 +57,11 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "(x86)|(X86)|(amd64)|(AMD64)")
 	set(CPU_OPTIMIZATION "-mmmx -msse -msse2" CACHE STRING "Which CPU specific optimitations should be used beside the compiler's default?")
 endif()
 
-option(USE_INTRINSICS "Compile using intrinsics (e.g mmx, sse, msse2)" ON)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "(powerpc|ppc)64le")
+	option(USE_INTRINSICS "Compile using intrinsics (e.g mmx, sse, msse2)" OFF)
+else()
+	option(USE_INTRINSICS "Compile using intrinsics (e.g mmx, sse, msse2)" ON)
+endif()
 
 option (MAKE_DLL "Make game.dll solution" ON)
 

--- a/neo/idlib/math/MatX.cpp
+++ b/neo/idlib/math/MatX.cpp
@@ -223,7 +223,11 @@ void idMatX::CopyLowerToUpperTriangle()
 	const __m128 mask2 = __m128c( _mm_set_epi32( 0, -1, -1, -1 ) );
 	const __m128 mask3 = __m128c( _mm_set_epi32( -1, -1, -1, -1 ) );
 	
-	const __m128 bottomMask[2] = { __m128c( _mm_set1_epi32( 0 ) ), __m128c( _mm_set1_epi32( -1 ) ) };
+	// const __m128 bottomMask[2] = { __m128c( _mm_set1_epi32( 0 ) ), __m128c( _mm_set1_epi32( -1 ) ) };
+	// compilers (e.g. MCST lcc, Intel icc) that use the C++ Front End from EDG (Edison Design Group) have a bug
+	// - no suitable conversion function from "__m128c" to "float"
+	// an explicit type conversion is used as a solution to this bug
+	const __m128 bottomMask[2] = { ( __m128 ) __m128c( _mm_set1_epi32( 0 ) ), ( __m128 ) __m128c( _mm_set1_epi32( -1 ) ) };
 	
 	float* __restrict basePtr = ToFloatPtr();
 	

--- a/neo/idlib/sys/sys_defines.h
+++ b/neo/idlib/sys/sys_defines.h
@@ -117,6 +117,8 @@ If you have questions concerning this license or the applicable additional terms
 #define CPUSTRING						"e2k"
 #elif defined(__aarch64__) || defined(__ARM64__) || defined(_M_ARM64)
 #define CPUSTRING 						"aarch64"
+#elif defined(__powerpc64__)
+#define CPUSTRING						"ppc64"
 #else
 #error unknown CPU
 #endif


### PR DESCRIPTION
- Added support of ppc64 architecture (backport from RBDoom-3-BFG)
Ref: https://github.com/RobertBeckebans/RBDOOM-3-BFG/pull/480

- Fixed build by MCST lcc compiler when using USE_INTRINSICS=ON option on e2k (Elbrus 2000) architecture
Ref: https://github.com/RobertBeckebans/RBDOOM-3-BFG/pull/495