### PR TITLE
Suggestions for next update

### DIFF
--- a/doomclassic/doom/r_segs.cpp
+++ b/doomclassic/doom/r_segs.cpp
@@ -368,7 +368,11 @@ R_StoreWallRange
     
     // calculate ::g->rw_distance for scale calculation
     ::g->rw_normalangle = ::g->curline->angle + ANG90;
-	offsetangle = abs((long)(::g->rw_normalangle-::g->rw_angle1));
+	if(!idStr::Icmp(CPUSTRING,"x86_64")){ //GK: One single cast to the wrong OS and CPU type can make all the graphical glitches 
+		offsetangle = abs((int)(::g->rw_normalangle-::g->rw_angle1)); 
+	}else{ 
+		offsetangle = abs((long)(::g->rw_normalangle-::g->rw_angle1)); 
+	} 
     
     if (offsetangle > ANG90)
 	offsetangle = ANG90;


### PR DESCRIPTION
nr 1 Original doom 3 text intro effects: at the very beginning of doom 3 there was a text cutscene about unlimited funds and if i remember good there was a background scary music and effects while on bfg edition there is no tv effects and muaic background just a text speech
![Screenshot_20201222-004805_YouTube](https://user-images.githubusercontent.com/61429596/102829266-683cec80-43ef-11eb-971a-67de4f4aadba.jpg) the doom 3 original intro effect and  nr 2: idk if thats done already but in original doom 3 when shooting a gun it flashes the enviroment while on bfg edition not and nr 3: physics corpses from original when killing someone in the same spot in doom 3 they stack up on each other while in bfg edition they just noclip though in 
![Screenshot_20201222-005531_YouTube](https://user-images.githubusercontent.com/61429596/102829757-74757980-43f0-11eb-8347-e5af7d164099.jpg)


