### PR TITLE
Update correct locale variables for Italian and Spanish

### DIFF
--- a/neo/sys/sys_local.cpp
+++ b/neo/sys/sys_local.cpp
@@ -388,11 +388,11 @@ const char* Sys_DefaultLanguage()
 		}
 		else if( currentLangList.Find( ID_LANG_ITALIAN ) )
 		{
-			sys_lang.SetString( ID_LANG_GERMAN );
+			sys_lang.SetString( ID_LANG_ITALIAN );
 		}
 		else if( currentLangList.Find( ID_LANG_SPANISH ) )
 		{
-			sys_lang.SetString( ID_LANG_GERMAN );
+			sys_lang.SetString( ID_LANG_SPANISH );
 		}
 		else
 		{


### PR DESCRIPTION
Locale variables when setting Spanish and Italian are pointing to German, so this fixes this issue.

Cheers!
