### PR TITLE
Always save cache

### DIFF
--- a/.github/workflows/cmake_linux_x64.yml
+++ b/.github/workflows/cmake_linux_x64.yml
@@ -65,6 +65,12 @@ jobs:
           working-directory: ${{github.workspace}}/neo
           run: cmake -B ${{github.workspace}}/build --preset=linux-${{inputs.build_type}}
     
+        - name: Save vcpkg_installed cache
+          uses: actions/cache/save@v3
+          with:
+              path: ${{github.workspace}}/build/vcpkg_installed
+              key: ${{runner.os}}-vcpkg-${{hashfiles('neo/linux-status')}}
+
         - name: Build
           id: step7
           env:

--- a/.github/workflows/cmake_windows_x64.yml
+++ b/.github/workflows/cmake_windows_x64.yml
@@ -57,6 +57,12 @@ jobs:
           shell: powershell
           run: cmake -B ${{github.workspace}}/build --preset=windows-x64-2022
           
+        - name: Save vcpkg_installed cache
+          uses: actions/cache/save@v3
+          with:
+              path: ${{github.workspace}}/build/vcpkg_installed
+              key: ${{runner.os}}-vcpkg-${{hashfiles('neo/windows-status')}}
+
         - name: Build
           # Build your program with the given configuration
           #run: cmake --build ${{github.workspace}}/build --config ${{inputs.build_type}}

--- a/.github/workflows/cmake_windows_x86.yml
+++ b/.github/workflows/cmake_windows_x86.yml
@@ -55,6 +55,12 @@ jobs:
               shell: powershell
               run: cmake -B ${{github.workspace}}/build --preset=windows-x86-2022
             
+            - name: Save vcpkg_installed cache
+              uses: actions/cache/save@v3
+              with:
+                  path: ${{github.workspace}}/build/vcpkg_installed
+                  key: ${{runner.os}}-vcpkg-${{hashfiles('neo/windows-32-bit-status')}}
+
             - name: Build
               # Build your program with the given configuration
               run: MSBuild ${{github.workspace}}/build/DoomBFA.vcxproj -property:Configuration=${{inputs.build_type}}


### PR DESCRIPTION
This saves the cache after successful CMake configuration, speeding up repeated builds of the same PR.